### PR TITLE
broadcasts the bottom-reached event each time the bottom is reached

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,10 @@ HTML
         <div>{{item.id}}</div>
         <div>{{item.description}}</div>
     </div>
+
+OPTION - setup a callback function that will be triggered by the "bottom-reached" event.
+This event is broadcast each time the bottom of the page is reached.
+	
+		$scope.$on('bottom-reached', function() {
+			// do whatever you want
+		});

--- a/source/scroll-repeat.js
+++ b/source/scroll-repeat.js
@@ -6,6 +6,9 @@ angular.module('ks.ngScrollRepeat', ['ks.WindowService'])
         var DEFAULT_TOLERANCE = 200;
 
         var safeApply = function(scope, fn) {
+            // broadcasts a new event each time the bottom is reached
+            scope.$broadcast('bottom-reached'); 
+
             if (scope.$$phase || scope.$root.$$phase) {
                 fn();
             } else {


### PR DESCRIPTION
See the README.md for more information.

==> setup a callback function that will be triggered by the "bottom-reached" event.
This event is broadcast each time the bottom of the page is reached.
	
		$scope.$on('bottom-reached', function() {
			// do whatever you want
		});

We needed that in our current project to be able to get more content from the REST API each time the bottom of the page is reached. 
In our case, we planned to use this new feature with a counter in order to limit the $http request every x bottom-reached event.