### PR TITLE
Deregister from scroll event on scope destroy

### DIFF
--- a/source/scroll-repeat.js
+++ b/source/scroll-repeat.js
@@ -62,6 +62,10 @@ angular.module('ks.ngScrollRepeat', ['ks.WindowService'])
                 });
 
                 windowService.registerForScroll($scope);
+
+                $scope.$on('$destroy', function() {
+                    windowService.deregisterForScroll($scope);
+                });
             };
         };
 

--- a/source/window-service.js
+++ b/source/window-service.js
@@ -26,6 +26,9 @@ angular.module('ks.WindowService', [])
                 } else {
                     throw new Error('Cannot register a non-scope object for scroll');
                 }
+            },
+            deregisterForScroll: function ($scope) {
+                listeners.splice(listeners.indexOf($scope), 1);
             }
         };
     }]);

--- a/test/scroll-repeat.test.js
+++ b/test/scroll-repeat.test.js
@@ -11,6 +11,7 @@ describe('Scroll Repeat Directive', function() {
                 height: function() {return windowHeight},
                 scrollTop: function() {return scrollTop},
                 registerForScroll: function() {},
+                deregisterForScroll: function() {},
                 WINDOW_SCROLL: 'WINDOW_SCROLL'
             };
             $provide.value('WindowService', mockWindowService);
@@ -151,5 +152,15 @@ describe('Scroll Repeat Directive', function() {
         scope.$digest();
 
         expect(element.find('.item').length).toBe(10);
+    });
+
+    it('deregisters when destroyed', function() {
+        mockWindowHeightAndScroll(20, 0);
+        compileDirective(10, 1, 0);
+        expect(element.find('.item').length).toBe(1);
+
+        spyOn(mockWindowService, 'deregisterForScroll');
+        scope.$destroy();
+        expect(mockWindowService.deregisterForScroll).toHaveBeenCalledWith(scope);
     });
 });

--- a/test/window-service.test.js
+++ b/test/window-service.test.js
@@ -46,6 +46,18 @@ describe('Window Service', function() {
         expect(scope2Listener.listener).toHaveBeenCalled();
     });
 
+    it('does not fire WINDOW_SCROLL event on unregistered scopes on scroll', function() {
+        spyOn(scope1Listener, 'listener');
+        spyOn(scope2Listener, 'listener');
+        windowService.registerForScroll(scope1);
+        windowService.registerForScroll(scope2);
+        windowService.deregisterForScroll(scope1);
+
+        $(window).trigger('scroll');
+        expect(scope1Listener.listener).not.toHaveBeenCalled();
+        expect(scope2Listener.listener).toHaveBeenCalled();
+    });
+
     it('fires WINDOW_SCROLL event on the scope on window scroll', function() {
         spyOn(scope1Listener, 'listener');
         spyOn(scope2Listener, 'listener');


### PR DESCRIPTION
There is a memory leak in the window service as it keeps references to destroyed scopes and calls them when scrolling. This patch makes sure the scopes are removed from the window service array when destroyed.